### PR TITLE
reorder package exports to make default last

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "commonjs",
   "exports": {
     ".": {
-      "default": "./lib/index.js",
-      "types": "./lib/index.d.ts"
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
     }
   },
   "main": "./lib/index.js",


### PR DESCRIPTION
I did not debug why containr was missing the lib directory in npm